### PR TITLE
Fix issue where recorder could not be reset

### DIFF
--- a/reformer_pytorch/recorder.py
+++ b/reformer_pytorch/recorder.py
@@ -40,6 +40,7 @@ class Recorder(nn.Module):
     def clear(self):
         del self.recordings
         self.recordings = defaultdict(list)
+        self.iter = 0        
 
     def record(self, attn, buckets):
         if not self.on: return


### PR DESCRIPTION
Without resetting the iter, new data gets inserted into the wrong array index.