### PR TITLE
Added **kwargs to the forward method of the Recorder

### DIFF
--- a/reformer_pytorch/recorder.py
+++ b/reformer_pytorch/recorder.py
@@ -47,12 +47,12 @@ class Recorder(nn.Module):
         data = {'attn': attn.detach().cpu(), 'buckets': buckets.detach().cpu()}
         self.recordings[self.iter].append(data)
 
-    def forward(self, x):
+    def forward(self, x, **kwargs):
         assert not self.ejected, 'Recorder has already been ejected and disposed'
         if self.on:
             self.wire()
 
-        out = self.net(x)
+        out = self.net(x, **kwargs)
 
         self.iter += 1
         self.unwire()


### PR DESCRIPTION
I was trying to visualize the attention of a model where the keys are passed in the forward method, like in the examples of the readme model(x, keys = enc_keys) and it gave me an error because the Recorder, which has to be wrapping the model in order to visualize the attention, didn't allow the extra parameters.

This PR aims to fix this by adding **kwargs in the recorder forward method signature.