### PR TITLE
Fix reversible args updates bug

### DIFF
--- a/reformer_pytorch/reformer_pytorch.py
+++ b/reformer_pytorch/reformer_pytorch.py
@@ -593,7 +593,7 @@ class Reformer(nn.Module):
             blocks.append(nn.ModuleList([f, g]))
 
         self.layers = ReversibleSequence(nn.ModuleList(blocks), layer_dropout = layer_dropout)
-        self.settables = filter(lambda x: isinstance(x, SettableArgs), self.layers.modules())
+        self.settables = list(filter(lambda x: isinstance(x, SettableArgs), self.layers.modules()))
 
     def set_reversible_args(self, *args, **kwargs):
         for module in self.settables:


### PR DESCRIPTION
Filter object with `SettableArgs` modules was iterated only during the first `model.forward()` call and then became empty. As a result, `**kwargs` with input and context masks were ignored on each subsequent `model.forward()` call.

Caught this error while training the Reformer model with `input_mask` and varying `batch_size`.

Bug was introduced in https://github.com/lucidrains/reformer-pytorch/commit/d2483dc88478f686a40cccb83b1759cbc338defa.