### PR TITLE
Fix backward multi round hashing

### DIFF
--- a/reformer_pytorch/reformer_pytorch.py
+++ b/reformer_pytorch/reformer_pytorch.py
@@ -426,11 +426,13 @@ class LSHAttention(nn.Module):
                 reshaped_st = st.view(st.shape[0], -1, total_hashes).unsqueeze(-1).expand(grad_x.shape)
                 reshaped_buckets_and_t = buckets_and_t.view(buckets_and_t.shape[0], -1, total_hashes)
 
+                # sort for each hash separately
                 so_grad = torch.gather(grad_x, 1, reshaped_st)
                 _, slogits_grad = sort_key_val(reshaped_buckets_and_t, grad_y, dim=-1)
 
                 so_grad = torch.reshape(so_grad, grad_x_shape)
                 slogits_grad = torch.reshape(slogits_grad, grad_y_shape)
+
                 return so_grad, slogits_grad, None
 
         o, logits = UnsortLogits.apply(so, slogits, total_hashes)


### PR DESCRIPTION
Hey @lucidrains,

Awesome work on reformer-pytorch. Your code helped me a lot to integrate Reformer into the hugging face library (here: https://huggingface.co/transformers/model_doc/reformer.html), so hopefully this PR helps you as well :-) 

I am quite confident that your code as it is now contains a bug so that the gradients are wrong for multi-round hashing (`n_hashes > 1`). 

In the customized backward of `UnsortLogits`, the gradients are currently re-sorted over all hash dimensions, but they should be re-sorted for each hash dimension individually.

 In the hugging face reformer code, I added gradient integration tests comparing the gradients to the original trax implementation. Here the code in current master:
https://github.com/huggingface/transformers/blob/1af58c07064d8f4580909527a8f18de226b226ee/tests/test_modeling_reformer.py#L931

or this branch for the full testing suite I had when developing the code:
https://github.com/huggingface/transformers/blob/branch_to_save_trax_integration_tests/tests/test_modeling_reformer.py

This PR should fix this error when calculating the gradients for `n_hashes > 1`.

I used this small script to test my changes:

```python
#!/usr/bin/env python3
import torch
from torch import randint

from reformer_pytorch import ReformerLM
from reformer_pytorch.generative_tools import TrainingWrapper

model = ReformerLM(
    num_tokens= 200,
    dim = 48,
    depth = 2,
    max_seq_len = 128,
    lsh_dropout = 0.1,
    causal = True,
    n_hashes=4
)

# 0 is used for padding and no loss to be calculated on it
model = TrainingWrapper(model, ignore_index = 0, pad_value = 0)

# the wrapper can handle evenly packed sequences
x_train = randint(0, 200, (128,)).unsqueeze(0)

# when training, set return_loss equal to True
model.train()

loss = model(x_train, return_loss = True)
loss.backward()
```

Maybe @nkitaev might be able to comment here as well :-) 
