### PR TITLE
Bug in layer norm

### DIFF
--- a/reformer_pytorch/reformer_pytorch.py
+++ b/reformer_pytorch/reformer_pytorch.py
@@ -702,7 +702,7 @@ class ReformerLM(nn.Module):
             self.pos_emb = AxialPositionalEmbedding(emb_dim, axial_position_shape)
 
         self.reformer = Reformer(dim, depth, max_seq_len, heads = heads, dim_head = dim_head, bucket_size = bucket_size, n_hashes = n_hashes, ff_chunks = ff_chunks, attn_chunks = attn_chunks, causal = causal, weight_tie = weight_tie, lsh_dropout = lsh_dropout, ff_mult = ff_mult, ff_activation = ff_activation, ff_glu = ff_glu, ff_dropout = ff_dropout, post_attn_dropout = 0., layer_dropout = layer_dropout, random_rotations_per_head = random_rotations_per_head, twin_attention = twin_attention, use_scale_norm = use_scale_norm, use_rezero = use_rezero, use_full_attn = use_full_attn, full_attn_thres = full_attn_thres, reverse_thres = reverse_thres, num_mem_kv = num_mem_kv, one_value_head = one_value_head, n_local_attn_heads = n_local_attn_heads, pkm_layers = pkm_layers, pkm_num_keys = pkm_num_keys)
-        self.norm = nn.LayerNorm(emb_dim)
+        self.norm = nn.LayerNorm(dim)
 
         if return_embeddings:
             self.out = Identity()


### PR DESCRIPTION
Normalization should be done on the output of the `reformer` object, and thus dimension should be `dim` and not `emb_dim`. 

